### PR TITLE
Use datetime instead of dateutils

### DIFF
--- a/gnucashxml.py
+++ b/gnucashxml.py
@@ -19,8 +19,8 @@
 
 import decimal
 import gzip
+import datetime
 
-from dateutil.parser import parse as parse_date
 from xml.etree import ElementTree
 
 __version__ = "1.0"
@@ -425,3 +425,7 @@ def _slots_from_tree(tree):
 def _parse_number(numstring):
     num, denum = numstring.split("/")
     return decimal.Decimal(num) / decimal.Decimal(denum)
+
+
+def parse_date(datetime_str):
+    datetime.datetime.strptime(datetime_str, '%Y-%m-%d %H:%M:%S %z')


### PR DESCRIPTION
This change would remove the dependency on dateutil module. Dates in gnucash XML outputs are like, for instance 2016-11-04 00:00:00 -0700, regardless of the locale it seems. And I haven't seen any other formats used in XML outputs. If there is let me know.